### PR TITLE
Correct Plugin Titles

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -1,5 +1,5 @@
 {
-  "name": "MusicControl",
+  "name": "Music Control",
   "author": "Miro Bouma",
   "flags": [],
   "publish": {

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -7,7 +7,7 @@ import { UsagePage } from "./pages/usage";
 export const InfoRoute: VFC = () => {
   return (
     <SidebarNavigation
-      title="MusicControl"
+      title="Music Control"
       showTitle
       pages={[
         {

--- a/src/routes/pages/info.tsx
+++ b/src/routes/pages/info.tsx
@@ -4,7 +4,7 @@ import { VFC } from "react";
 export const InfoPage: VFC = () => {
   return (
     <Focusable>
-      MusicControl allows you to control any media playback that is currently
+      Music Control allows you to control any media playback that is currently
       running that implements the MPRIS dbus interface. <br />
       Examples of application that are supported:
       <ul>


### PR DESCRIPTION
This should be all that is necessary to correct the plugin's titles through-out user-interfaces. Only during filesystem access should spaces be removed or escaped (or otherwise use things such as underscores or dashes).