### PR TITLE
Fix to use the configured user directory for caching

### DIFF
--- a/main.py
+++ b/main.py
@@ -5,6 +5,8 @@ import os
 import sys
 import shutil
 
+import decky_plugin
+
 SP_DEST = "org.mpris.MediaPlayer2.spotify"
 
 MP_PATH = "/org/mpris/MediaPlayer2"
@@ -189,8 +191,8 @@ class Plugin:
     async def _main(self):
         print(f"[MusicControl] UID: {os.getuid()}")
         sys.stdout.flush()
-        self.cacheDir = "/home/deck/.deckycache/MusicControl"
-        self.symLinkPath = "/home/deck/.local/share/Steam/steamui/images/deckycache_musicControl"
+        self.cacheDir = os.path.join(decky_plugin.DECKY_PLUGIN_RUNTIME_DIR, "cache")
+        self.symLinkPath = os.path.join(decky_plugin.DECKY_USER_HOME, ".local/share/Steam/steamui/images/deckycache_musicControl")
 
         self.previousCachedImage = ""
         self.player = SP_DEST


### PR DESCRIPTION
The `cacheDir` uses a hard-coded directory of `/home/deck/`, I managed to get decky-loader working on my normal install with my own user but ran into errors because of that hard-coded directory.
Thought I'd give it a shot to make a fix. It's working again on my machine with this PR, but I don't have a steam deck to test it with.